### PR TITLE
Use CalVer calendar based versioning

### DIFF
--- a/custom_components/bom/manifest.json
+++ b/custom_components/bom/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://github.com/DavidFW1960/bom_core_replacement",
   "requirements": ["bomradarloop==0.1.5"],
   "codeowners": ["@davidfw1960"],
-  "version": "0.0.0"
+  "version": "2021.3.1"
 }


### PR DESCRIPTION
Having the version set to 0.0.0 doesn't mean anything, and could backfire if any changes need to be made to the code in the future, as HACS will only pick up a change if the version changes.

Recommend using CalVer, similar to HA versioning: YEAR.MONTH.VERSION
That way the version tells you when it was last updated.